### PR TITLE
Update Rubocop rules

### DIFF
--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -1,6 +1,17 @@
+# Rubocop version 0.39.0
+# Base-style configuration. This should be included in all projects.
+require: rubocop-rspec
+
 AllCops:
+  DisplayCopNames: true
+  Include:
+    - '**/Rakefile'
+    - '**/config.ru'
   Exclude:
-    - db/schema.rb
+    - 'db/**/*'
+    - 'script/**/*'
+    - 'tmp/**/*'
+    - 'vendor/**/*'
 
 Style/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.
@@ -31,10 +42,28 @@ Style/Attr:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#attr'
   Enabled: false
 
+Style/BlockDelimiters:
+  Description: 'Check for uses of braces or do/end around single line or multi-line blocks.'
+  Enabled: true
+  Exclude:
+    - 'spec/**/*'
+
+Style/BlockEndNewline:
+  Description: 'Checks whether the end statement of a do..end block is on its own line.'
+  Enabled: true
+  Exclude:
+    - 'spec/**/*'
+
 Metrics/BlockNesting:
   Description: 'Avoid excessive block nesting'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#three-is-the-number-thou-shalt-count'
   Enabled: false
+
+Style/BracesAroundHashParameters:
+  Description: >-
+                Checks for braces around the last parameter in a method call if the last parameter is a hash.
+                It supports 3 styles: braces, no_braces, context_dependent
+  Enabled: true
 
 Style/CaseEquality:
   Description: 'Avoid explicit use of the case equality operator(===).'
@@ -66,7 +95,6 @@ Style/ClassVars:
 Style/CollectionMethods:
   Enabled: true
   PreferredMethods:
-    find: detect
     inject: reduce
     collect: map
     collect!: map!
@@ -91,13 +119,6 @@ Metrics/AbcSize:
                  branches, and conditions.
   Enabled: false
 
-Metrics/BlockLength:
-  CountComments: true  # count full line comments?
-  Max: 25
-  ExcludedMethods: []
-  Exclude:
-    - "spec/**/*"
-
 Metrics/CyclomaticComplexity:
   Description: >-
                  A complexity metric that is strongly correlated to the number
@@ -105,15 +126,13 @@ Metrics/CyclomaticComplexity:
   Enabled: true
 
 Metrics/PerceivedComplexity:
+  Description: >-
+                This cop tries to produce a complexity score that's a measure of the complexity
+                the reader experiences when looking at a method
   Enabled: true
 
 Rails/Delegate:
   Description: 'Prefer delegate method for delegations.'
-  Enabled: false
-
-Style/PreferredHashMethods:
-  Description: 'Checks use of `has_key?` and `has_value?` Hash methods.'
-  StyleGuide: '#hash-key'
   Enabled: false
 
 Style/Documentation:
@@ -188,6 +207,10 @@ Style/IfWithSemicolon:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-semicolon-ifs'
   Enabled: false
 
+Style/IndentationConsistency:
+  Description: 'Checks for inconsistent indentation.'
+  EnforcedStyle: rails
+
 Style/InlineComment:
   Description: 'Avoid inline comments.'
   Enabled: false
@@ -227,6 +250,12 @@ Style/MultilineBlockChain:
   Description: 'Avoid multi-line chains of blocks.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#single-line-blocks'
   Enabled: false
+
+Style/MultilineBlockLayout:
+  Description: 'Checks whether the multiline do end blocks have a newline after the start of the block.'
+  Enabled: true
+  Exclude:
+    - 'spec/**/*'
 
 Style/NegatedIf:
   Description: >-
@@ -346,29 +375,39 @@ Style/StringLiterals:
   Enabled: true
 
 Style/TrailingCommaInArguments:
-  Description: 'Checks for trailing comma in argument lists.'
+  Description: >-
+                Checks for trailing comma in argument lists. Supported styles are:
+                  comma
+                  consistent_comma
+                  no_comma
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
-  EnforcedStyleForMultiline: comma
-  SupportedStylesForMultiline:
-    - comma
-    - consistent_comma
-    - no_comma
+  EnforcedStyleForMultiline: no_comma
   Enabled: true
 
 Style/TrailingCommaInLiteral:
-  Description: 'Checks for trailing comma in array and hash literals.'
+  Description: >-
+                Checks for trailing comma in array and hash literals. Supported styles are:
+                  comma
+                  consistent_comma
+                  no_comma
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
-  EnforcedStyleForMultiline: comma
-  SupportedStylesForMultiline:
-    - comma
-    - consistent_comma
-    - no_comma
+  EnforcedStyleForMultiline: no_comma
   Enabled: true
 
 Style/TrivialAccessors:
   Description: 'Prefer attr_* methods to trivial readers/writers.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#attr_family'
   Enabled: false
+
+Lint/UselessAssignment:
+  Description: >-
+                Checks for every useless assignment to local variable in every scope.
+                The basic idea for this cop was from the warning of `ruby -cw`:'
+  Enabled: true
+
+Style/VariableName:
+  Description: 'Makes sure that all variables use the configured style, snake_case or camelCase, for their names.'
+  Enabled: true
 
 Style/VariableInterpolation:
   Description: >-
@@ -396,35 +435,35 @@ Style/WordArray:
 
 # Layout
 
-Layout/AlignParameters:
+Style/AlignParameters:
   Description: 'Here we check if the parameters on a multi-line method call or definition are aligned.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-double-indent'
   Enabled: false
 
-Layout/DotPosition:
+Style/DotPosition:
   Description: 'Checks the position of the dot in multi-line method calls.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains'
-  EnforcedStyle: trailing
+  EnforcedStyle: leading
 
-Layout/ExtraSpacing:
+Style/ExtraSpacing:
   Description: 'Do not use unnecessary spacing.'
   Enabled: true
 
-Layout/MultilineOperationIndentation:
+Style/MultilineOperationIndentation:
   Description: >-
                  Checks indentation of binary operations that span more than
                  one line.
   Enabled: true
   EnforcedStyle: indented
 
-Layout/MultilineMethodCallIndentation:
+Style/MultilineMethodCallIndentation:
   Description: >-
                  Checks indentation of method calls with the dot operator
                  that span more than one line.
   Enabled: true
   EnforcedStyle: indented
 
-Layout/InitialIndentation:
+Style/InitialIndentation:
   Description: >-
     Checks the indentation of the first non-blank non-comment line in a file.
   Enabled: false
@@ -602,6 +641,9 @@ Performance/StringReplacement:
 
 # Rails
 
+Rails:
+  Enabled: true
+
 Rails/ActionFilter:
   Description: 'Enforces consistent use of action filter methods.'
   Enabled: false
@@ -647,3 +689,23 @@ Rails/TimeZone:
 Rails/Validation:
   Description: 'Use validates :attribute, hash of validations.'
   Enabled: false
+
+# RSpec
+
+RSpec/ExampleWording:
+  CustomTransform:
+    be: is
+    have: has
+    not: does not
+    NOT: does NOT
+  IgnoredWords:
+    - only
+
+RSpec/FilePath:
+  Enabled: false
+
+RSpec/InstanceVariable:
+  Enabled: false
+
+RSpec/DescribeClass:
+  Enabled: true


### PR DESCRIPTION
Here's the first PR to our style guide!

This aligns our guide with the current rubocop configuration that we're using. The guide I copied from used a newer version of rubocop, so some cops that aren't available were removed or renamed.

From this point onward, we can make overall changes to the configuration in this repo and then reference it in the local rubocop.yml files of our respective projects.